### PR TITLE
ci: use repo test-user secrets for guide screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read app version
         id: app_version
@@ -30,7 +30,7 @@ jobs:
           echo "app_version=${APP_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,12 +82,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/user-guide-pages.yml
+++ b/.github/workflows/user-guide-pages.yml
@@ -29,12 +29,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -77,12 +77,12 @@ jobs:
       - name: Capture live production screenshots
         env:
           PLAYWRIGHT_BASE_URL: https://www.quizymode.com/
-          TEST_USER_EMAIL: test-user@quizymode.com
-          TEST_USER_PASSWORD: ${{ secrets.QM_AGENT_USER_TEST_PWD }}
+          TEST_USER_EMAIL: ${{ vars.TEST_USER_EMAIL || secrets.TEST_USER_EMAIL || 'test-user@quizymode.com' }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD || secrets.QM_AGENT_USER_TEST_PWD }}
           USER_GUIDE_SCREENSHOT_ROOT: ${{ runner.temp }}/user-guide-screenshots
         run: |
           if [ -z "${TEST_USER_PASSWORD}" ]; then
-            echo "QM_AGENT_USER_TEST_PWD is required to capture the user guide." >&2
+            echo "TEST_USER_PASSWORD (or legacy QM_AGENT_USER_TEST_PWD) is required to capture the user guide." >&2
             exit 1
           fi
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: user-guide-debug-${{ github.run_id }}
           path: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <QuizymodeVersion>3.17.0</QuizymodeVersion>
+    <QuizymodeVersion>3.17.1</QuizymodeVersion>
     <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
   </PropertyGroup>
 </Project>

--- a/src/Quizymode.Web/package-lock.json
+++ b/src/Quizymode.Web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizymode-web",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizymode-web",
-      "version": "3.17.0",
+      "version": "3.17.1",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",

--- a/src/Quizymode.Web/package.json
+++ b/src/Quizymode.Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quizymode-web",
   "private": true,
-  "version": "3.17.0",
+  "version": "3.17.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
- [x] use repo test-user secrets for guide screenshots
- [x]  upgrade github actions to node24-ready versions
