### PR TITLE
Fix/perf issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ dotnet build src/Quizymode.Api/Quizymode.Api.csproj --configuration Release
 | Variable | Typical value |
 |---|---|
 | `QM_AGENT_LOCAL_PGHOST` | `localhost` |
-| `QM_AGENT_LOCAL_PGPORT` | `49800` |
+| `QM_AGENT_LOCAL_PGPORT` | `55432` |
 | `QM_AGENT_LOCAL_PGDATABASE` | `quizymode` |
 | `QM_AGENT_LOCAL_PGUSER` | `postgres` |
 | `QM_AGENT_LOCAL_PGPASSWORD` | *(secret — never print)* |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <QuizymodeVersion>3.18.9</QuizymodeVersion>
+    <QuizymodeVersion>3.19.0</QuizymodeVersion>
     <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <QuizymodeVersion>3.18.7</QuizymodeVersion>
+    <QuizymodeVersion>3.18.9</QuizymodeVersion>
     <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In practice, local development is:
 ### Database
 
 - PostgreSQL runs through Aspire in local development.
-- The AppHost pins the local PostgreSQL host port to `49800` and keeps the password stable through the AppHost user-secrets store, so local agent/test env vars do not need to change on every container recreation.
+- The AppHost pins the local PostgreSQL host port to `55432` and keeps the password stable through the AppHost user-secrets store, so local agent/test env vars do not need to change on every container recreation.
 - EF Core migrations are applied automatically on API startup.
 - Seed data is loaded from `data/seed-dev/`.
 

--- a/data/seed-source/_registry/item-index.csv
+++ b/data/seed-source/_registry/item-index.csv
@@ -1,4 +1,4 @@
-﻿ItemId,Category,NavigationKeyword1,NavigationKeyword2,QuestionPrefix50,SourceFile
+ItemId,Category,NavigationKeyword1,NavigationKeyword2,QuestionPrefix50,SourceFile
 1a86d320-21aa-43a0-8b54-085e2df32430,business,accounting,audit,How does a review engagement typically differ from,data/seed-source/items/business/business.accounting.audit.json
 665f4244-583c-4ab0-983d-004c3b65cc36,business,accounting,audit,"In an audit, what is the role of internal controls",data/seed-source/items/business/business.accounting.audit.json
 f28b0cdf-a28b-472d-8d00-f46d632d2eaf,business,accounting,audit,"In basic audit terminology, what is audit sampling",data/seed-source/items/business/business.accounting.audit.json
@@ -943,7 +943,7 @@ f8134692-3915-404a-90b9-0a8a73e4bab9,exams,aws,saa-c03,A company has a three-tie
 a08d9f0a-3b87-4950-b662-6f12986b6bf2,exams,aws,saa-c03,A company has a web application with sporadic usag,data/seed-source/items/exams/exams.aws.saa-c03-p20.json
 6669138d-8604-4a38-9dbd-d5bae823df40,exams,aws,saa-c03,A company has a website hosted on AWS. The website,data/seed-source/items/exams/exams.aws.saa-c03-p04.json
 7a6b8c67-f1f5-4a97-9494-ec13d8aad57d,exams,aws,saa-c03,A company has an API that receives real-time data ,data/seed-source/items/exams/exams.aws.saa-c03-p11.json
-34f305b8-7fc6-4d07-a399-ce4fba4e54d4,exams,aws,saa-c03,"A company has an AWS Glue extraffict, transform, a",data/seed-source/items/exams/exams.aws.saa-c03-p06.json
+34f305b8-7fc6-4d07-a399-ce4fba4e54d4,exams,aws,saa-c03,"A company has an AWS Glue extract, transform, and ",data/seed-source/items/exams/exams.aws.saa-c03-p06.json
 67686978-2fdb-4b86-adde-5efbe85965fc,exams,aws,saa-c03,A company has an AWS Lambda function that needs re,data/seed-source/items/exams/exams.aws.saa-c03-p14.json
 5cb1ed8b-eeac-4056-a476-0fc502f3b2c4,exams,aws,saa-c03,A company has an AWS account used for software eng,data/seed-source/items/exams/exams.aws.saa-c03-p10.json
 f5593625-a083-428a-975a-a418279504bd,exams,aws,saa-c03,A company has an Amazon S3 data lake that is gover,data/seed-source/items/exams/exams.aws.saa-c03-p16.json
@@ -1121,7 +1121,7 @@ d0866627-7352-4c48-b8ac-c7fda4750563,exams,aws,saa-c03,A company is running a cu
 c76c9e16-2a1c-4471-8879-28a3b3f46c0b,exams,aws,saa-c03,A company is running a microservices application o,data/seed-source/items/exams/exams.aws.saa-c03-p24.json
 7f0353a4-cbf5-48cd-8ec3-9398f80e8d19,exams,aws,saa-c03,A company is running a multi-tier ecommerce web ap,data/seed-source/items/exams/exams.aws.saa-c03-p19.json
 e3f887d7-7d4e-4512-a539-1ec85c2a5062,exams,aws,saa-c03,A company is running a popular social media websit,data/seed-source/items/exams/exams.aws.saa-c03-p04.json
-d0468f74-015b-47e7-a32c-20c4ebb06108,exams,aws,saa-c03,A company is running an SMB le server in its data ,data/seed-source/items/exams/exams.aws.saa-c03-p02.json
+d0468f74-015b-47e7-a32c-20c4ebb06108,exams,aws,saa-c03,A company is running an SMB file server in its dat,data/seed-source/items/exams/exams.aws.saa-c03-p02.json
 bb0ccb9c-2f2a-4b00-a9ac-9a5a2d1c3d43,exams,aws,saa-c03,A company is running an online transaction process,data/seed-source/items/exams/exams.aws.saa-c03-p07.json
 1e2c85d0-022f-4d8c-913e-8be34550db58,exams,aws,saa-c03,A company is running its production and nonproduct,data/seed-source/items/exams/exams.aws.saa-c03-p20.json
 e8d7623e-5aea-4a04-8c83-a4d7eefd18b2,exams,aws,saa-c03,A company is running several business applications,data/seed-source/items/exams/exams.aws.saa-c03-p18.json
@@ -1215,7 +1215,7 @@ da3feec1-1273-46ef-b429-b2dfc48fd37b,exams,aws,saa-c03,A company runs a web appl
 8ab96d09-2535-4a0f-975e-da4d47ccd4ae,exams,aws,saa-c03,A company runs a web-based portal that provides us,data/seed-source/items/exams/exams.aws.saa-c03-p08.json
 37f7f10f-af6e-437d-aad2-099e927151ea,exams,aws,saa-c03,A company runs a website that stores images of his,data/seed-source/items/exams/exams.aws.saa-c03-p30.json
 441c535a-8ce8-476c-b8d7-6db3bb6da241,exams,aws,saa-c03,A company runs an Oracle database on premises. As ,data/seed-source/items/exams/exams.aws.saa-c03-p07.json
-279894c7-2d6d-40af-b28d-5ef5cba34d89,exams,aws,saa-c03,A company runs an SMB le server in its data center,data/seed-source/items/exams/exams.aws.saa-c03-p31.json
+279894c7-2d6d-40af-b28d-5ef5cba34d89,exams,aws,saa-c03,A company runs an SMB file server in its data cent,data/seed-source/items/exams/exams.aws.saa-c03-p31.json
 882ae939-8b6c-4d79-bc59-50b0a8bece70,exams,aws,saa-c03,A company runs an application in a VPC with public,data/seed-source/items/exams/exams.aws.saa-c03-p26.json
 d2577951-cea9-4e34-acc0-ce31431012d3,exams,aws,saa-c03,A company runs an application on AWS. The applicat,data/seed-source/items/exams/exams.aws.saa-c03-p26.json
 eb4b4e61-dafc-4531-9abd-c553b7a570c1,exams,aws,saa-c03,A company runs an application on Amazon EC2 Linux ,data/seed-source/items/exams/exams.aws.saa-c03-p18.json
@@ -1346,7 +1346,7 @@ a9323d5a-b0d8-484c-834d-d145874cf4d0,exams,aws,saa-c03,A company's website handl
 c8ec0f5f-6481-48e0-935e-5009d23441d0,exams,aws,saa-c03,A company's website uses an Amazon EC2 instance st,data/seed-source/items/exams/exams.aws.saa-c03-p04.json
 8a9621aa-dfb8-404e-aed6-2dd3748dd5e3,exams,aws,saa-c03,A company’s application is having performance issu,data/seed-source/items/exams/exams.aws.saa-c03-p11.json
 342d65fe-22ae-4123-9eb8-bea14fac34b6,exams,aws,saa-c03,A company’s application runs on Amazon EC2 instanc,data/seed-source/items/exams/exams.aws.saa-c03-p16.json
-61367752-1211-4aaa-9a2e-40221fde0403,exams,aws,saa-c03,A company’s compliance team needs to move its fifi,data/seed-source/items/exams/exams.aws.saa-c03-p13.json
+61367752-1211-4aaa-9a2e-40221fde0403,exams,aws,saa-c03,A company’s compliance team needs to move its file,data/seed-source/items/exams/exams.aws.saa-c03-p13.json
 22f48810-dc6a-431c-a703-147e26f7efd3,exams,aws,saa-c03,A company’s facility has badge readers at every en,data/seed-source/items/exams/exams.aws.saa-c03-p16.json
 04f551a9-6085-425a-8a40-a3b817f65db2,exams,aws,saa-c03,A company’s infrastructure consists of Amazon EC2 ,data/seed-source/items/exams/exams.aws.saa-c03-p09.json
 e86e1174-b36b-4e94-9239-2ada1078e19a,exams,aws,saa-c03,A company’s order system sends requests from clien,data/seed-source/items/exams/exams.aws.saa-c03-p10.json
@@ -1401,7 +1401,7 @@ af9cc3a9-a058-4743-9f72-3d015d83074b,exams,aws,saa-c03,A social media company is
 285f76f3-81e9-41be-af26-97f251cbfe1a,exams,aws,saa-c03,A social media company runs its application on Ama,data/seed-source/items/exams/exams.aws.saa-c03-p17.json
 66eaaee7-3a21-42e6-94da-172558f3002a,exams,aws,saa-c03,A social media company wants to allow its users to,data/seed-source/items/exams/exams.aws.saa-c03-p24.json
 13a01115-8cf8-494f-8fbe-b88bb20a0710,exams,aws,saa-c03,A social media company wants to store its database,data/seed-source/items/exams/exams.aws.saa-c03-p29.json
-e0b6675b-847f-49f9-b5cb-049c873206f7,exams,aws,saa-c03,A solutions architect congured a VPC that has a sm,data/seed-source/items/exams/exams.aws.saa-c03-p21.json
+e0b6675b-847f-49f9-b5cb-049c873206f7,exams,aws,saa-c03,A solutions architect configured a VPC that has a ,data/seed-source/items/exams/exams.aws.saa-c03-p21.json
 62c16ae8-83db-4938-9b8a-c08f6890df64,exams,aws,saa-c03,A solutions architect has created two IAM policies,data/seed-source/items/exams/exams.aws.saa-c03-p13.json
 f5fdd3a0-8747-4176-8401-7fb4cb571ce7,exams,aws,saa-c03,A solutions architect is creating a data processin,data/seed-source/items/exams/exams.aws.saa-c03-p29.json
 b54e1121-b621-425a-a503-8f21a071351e,exams,aws,saa-c03,A solutions architect is creating a new Amazon Clo,data/seed-source/items/exams/exams.aws.saa-c03-p09.json
@@ -1486,19 +1486,19 @@ cf58afd7-ad7a-4a0d-aadc-1686ce79d1ec,exams,aws,saa-c03,"As part of budget planni
 f439c838-36df-4d42-a6ac-cc1761d9e985,exams,aws,saa-c03,Organizers for a global event want to put daily re,data/seed-source/items/exams/exams.aws.saa-c03-p09.json
 3ff7e2af-a7fc-4f72-b3c4-a061aa71b179,exams,aws,saa-c03,The customers of a nance company request appointme,data/seed-source/items/exams/exams.aws.saa-c03-p10.json
 8a8e6492-e365-477a-afc6-647762985d56,exams,aws,saa-c03,The following IAM policy is attached to an IAM gro,data/seed-source/items/exams/exams.aws.saa-c03-p20.json
-de1088b8-8a96-4c26-bc69-4fbcebb4d02a,exams,aws,saa-c03,What lets instances in a private subnet reach the ,data/seed-source/items/exams/exams.aws.saa-c03.json
+de1088b8-8a96-4c26-bc69-4fbcebb4d02a,exams,aws,saa-c03,What lets instances in a private subnet reach the ,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
 3e10e638-eee4-4c49-9615-c6875b42dc1b,exams,aws,saa-c03,What should a solutions architect do to ensure tha,data/seed-source/items/exams/exams.aws.saa-c03-p16.json
-f3a9c221-4a2b-44fc-8159-4a11f2880763,exams,aws,saa-c03,Which AWS database service is a fully managed serv,data/seed-source/items/exams/exams.aws.saa-c03.json
-e17ec24a-14f8-4d0b-9b68-3ede1ad76273,exams,aws,saa-c03,Which AWS relational database service is compatibl,data/seed-source/items/exams/exams.aws.saa-c03.json
-37ff4240-90b6-4081-b834-1eda92ac44cd,exams,aws,saa-c03,Which AWS service automatically adjusts capacity t,data/seed-source/items/exams/exams.aws.saa-c03.json
-6cbd25a9-d45c-495d-a672-39a77472804c,exams,aws,saa-c03,Which AWS service distributes incoming traffic acr,data/seed-source/items/exams/exams.aws.saa-c03.json
-3b482677-bf30-4e50-a37a-926f7e6c1b6d,exams,aws,saa-c03,Which AWS service is a content delivery network fo,data/seed-source/items/exams/exams.aws.saa-c03.json
-99008e5d-b346-4962-a0e4-12a2b84e91e4,exams,aws,saa-c03,Which AWS service is used for infrastructure as co,data/seed-source/items/exams/exams.aws.saa-c03.json
-2d3cab62-2904-4ac3-863d-9b1f0509ecc7,exams,aws,saa-c03,Which AWS service provides DNS routing for interne,data/seed-source/items/exams/exams.aws.saa-c03.json
-833092c9-4dd8-4863-b94c-d8f648d09859,exams,aws,saa-c03,"Which AWS service sends, stores, and receives mess",data/seed-source/items/exams/exams.aws.saa-c03.json
-6d9c773e-66c5-43b1-9dbd-e63f5b8b0a0d,exams,aws,saa-c03,Which AWS storage service provides a shared file s,data/seed-source/items/exams/exams.aws.saa-c03.json
-b410980a-475f-48bb-a6b6-1b5c3ff88e36,exams,aws,saa-c03,Which AWS storage service provides block volumes t,data/seed-source/items/exams/exams.aws.saa-c03.json
-b7b5d12c-55a7-4eff-b349-b2bad29e45c4,exams,aws,saa-c03,Which Amazon S3 storage class is designed for data,data/seed-source/items/exams/exams.aws.saa-c03.json
+f3a9c221-4a2b-44fc-8159-4a11f2880763,exams,aws,saa-c03,Which AWS database service is a fully managed serv,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+e17ec24a-14f8-4d0b-9b68-3ede1ad76273,exams,aws,saa-c03,Which AWS relational database service is compatibl,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+37ff4240-90b6-4081-b834-1eda92ac44cd,exams,aws,saa-c03,Which AWS service automatically adjusts capacity t,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+6cbd25a9-d45c-495d-a672-39a77472804c,exams,aws,saa-c03,Which AWS service distributes incoming traffic acr,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+3b482677-bf30-4e50-a37a-926f7e6c1b6d,exams,aws,saa-c03,Which AWS service is a content delivery network fo,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+99008e5d-b346-4962-a0e4-12a2b84e91e4,exams,aws,saa-c03,Which AWS service is used for infrastructure as co,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+2d3cab62-2904-4ac3-863d-9b1f0509ecc7,exams,aws,saa-c03,Which AWS service provides DNS routing for interne,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+833092c9-4dd8-4863-b94c-d8f648d09859,exams,aws,saa-c03,"Which AWS service sends, stores, and receives mess",data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+6d9c773e-66c5-43b1-9dbd-e63f5b8b0a0d,exams,aws,saa-c03,Which AWS storage service provides a shared file s,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+b410980a-475f-48bb-a6b6-1b5c3ff88e36,exams,aws,saa-c03,Which AWS storage service provides block volumes t,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
+b7b5d12c-55a7-4eff-b349-b2bad29e45c4,exams,aws,saa-c03,Which Amazon S3 storage class is designed for data,data/seed-source/items/exams/exams.aws.saa-c03-p01.json
 1b4ef870-f355-4c0e-90ab-335495037ba7,exams,aws,sap-c02,Which AWS DNS service routes end users to internet,data/seed-source/items/exams/exams.aws.sap-c02.json
 5cc25e9f-1c21-4c6d-a87b-6e81145ea872,exams,aws,sap-c02,Which AWS relational database service automates pr,data/seed-source/items/exams/exams.aws.sap-c02.json
 30c2b1fe-9b9d-4f6d-a92a-177c13189aa8,exams,aws,sap-c02,Which AWS service automatically adjusts capacity t,data/seed-source/items/exams/exams.aws.sap-c02.json

--- a/docs/AC.md
+++ b/docs/AC.md
@@ -1059,6 +1059,19 @@ The ideas board is a public-facing product planning surface at `/ideas`. It show
 
 ---
 
+## AC 8. Performance characteristics
+
+### AC 8.1 Database query behaviour
+
+- **AC 8.1.1** `GET /collections` retrieves item counts for all user collections in a single batched `GROUP BY` query, not a correlated subquery per collection.
+- **AC 8.1.2** `GET /ideas` and related idea-board endpoints aggregate rating counts and averages in SQL (a `GROUP BY` projection); rating rows are not loaded into application memory for aggregation.
+- **AC 8.1.3** Multi-keyword item filtering (`?keywords=a,b`) uses a single correlated `COUNT` subquery with AND semantics, not one `EXISTS` subquery per keyword.
+- **AC 8.1.4** Admin page-view analytics computes authenticated/anonymous page-view and session counts in a single `GROUP BY IsAuthenticated` query, not four separate count queries.
+- **AC 8.1.5** All read-only item, comment, and rating queries use `AsNoTracking()` so EF Core does not maintain change-tracking state for entities that are never modified.
+- **AC 8.1.6** The database has indexes on `CollectionItems(CollectionId)`, `CollectionItems(ItemId)`, `LOWER(Keywords.Name)`, and `LOWER(Categories.Name)` to support efficient joins and case-insensitive name lookups.
+
+---
+
 ## Unclarities / questions for product owner
 
 - **Shareable link vs IsPublic**: Resolved — if a collection is **not** shared with others (IsPublic = false), only the owner can access it by ID or link. When **Shared with others** is on (IsPublic = true), anyone with the link (or who finds it by ID or via Discover) can view and quiz, and the collection appears in Discover. The UI uses the label **"Shared with others"** for this toggle. Users can search or enter a collection ID to open it (see AC 1.9.6).

--- a/src/Quizymode.Api.AppHost/AppHost.cs
+++ b/src/Quizymode.Api.AppHost/AppHost.cs
@@ -1,5 +1,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Configuration;
+using System.Diagnostics;
 using System.Net.Sockets;
 
 static string GetAudienceValue(IConfiguration configuration)
@@ -22,7 +23,28 @@ static string GetAudienceValue(IConfiguration configuration)
 static int GetLocalPostgresPort(IConfiguration configuration)
 {
     int? configuredPort = configuration.GetValue<int?>("LocalInfrastructure:Postgres:Port");
-    return configuredPort ?? 49800;
+    return configuredPort ?? 55432;
+}
+
+// Kill any stale processes on known ports before Aspire starts resources.
+// This prevents "port already in use" failures when VS is restarted after a force-kill.
+if (OperatingSystem.IsWindows())
+{
+    foreach (int port in new[] { 8082, 7000 })
+        KillPortWindows(port);
+}
+
+static void KillPortWindows(int port)
+{
+    using Process? p = Process.Start(new ProcessStartInfo("powershell.exe",
+        $"-NoProfile -Command \"Get-NetTCPConnection -LocalPort {port} -ErrorAction SilentlyContinue " +
+        $"| ForEach-Object {{ Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }}\"")
+    {
+        UseShellExecute = false,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+    });
+    p?.WaitForExit(3_000);
 }
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -95,19 +117,12 @@ var api = builder.AddProject("quizymode-api", "../Quizymode.Api/Quizymode.Api.cs
 // Add the React/Vite dev server via AddExecutable (Aspire.Hosting.NodeJs is not yet released
 // at the Aspire 13.x version, so we drive npm directly).
 // vite.config.ts reads the PORT env var set here; falls back to 7000 for standalone npm run dev.
-// Start the React/Vite dev server.
-// Kill any stale process on port 7000 first so Vite always binds to the expected port.
 // No endpoint registration needed — navigate to http://localhost:7000 directly.
-string npmExe = OperatingSystem.IsWindows() ? "powershell.exe" : "sh";
+// Stale processes on port 7000 are already killed above before Aspire starts.
+string npmExe = OperatingSystem.IsWindows() ? "cmd.exe" : "sh";
 string[] npmArgs = OperatingSystem.IsWindows()
-    ? [
-        "-NoProfile", "-Command",
-        "Get-NetTCPConnection -LocalPort 7000 -ErrorAction SilentlyContinue " +
-        "| ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }; " +
-        "Start-Sleep -Milliseconds 300; " +
-        "npm run dev"
-      ]
-    : ["-c", "fuser -k 7000/tcp 2>/dev/null; sleep 0.3; npm run dev"];
+    ? ["/c", "npm run dev"]
+    : ["-c", "npm run dev"];
 
 builder.AddExecutable("quizymode-web", npmExe, "../../src/Quizymode.Web", npmArgs)
     .WaitFor(api);

--- a/src/Quizymode.Api.AppHost/appsettings.Development.json
+++ b/src/Quizymode.Api.AppHost/appsettings.Development.json
@@ -9,7 +9,7 @@
   },
   "LocalInfrastructure": {
     "Postgres": {
-      "Port": 49800,
+      "Port": 55432,
       "Username": "postgres"
     }
   }

--- a/src/Quizymode.Api/Features/Admin/GetPageViewAnalytics.cs
+++ b/src/Quizymode.Api/Features/Admin/GetPageViewAnalytics.cs
@@ -150,16 +150,35 @@ public static class GetPageViewAnalytics
         int totalPages = totalCount == 0 ? 0 : (int)Math.Ceiling(totalCount / (double)pageSize);
         int skip = (page - 1) * pageSize;
 
+        // Batch auth-split stats into one GROUP BY query (4 sequential queries → 1)
+        var authBreakdowns = await query
+            .GroupBy(pv => pv.IsAuthenticated)
+            .Select(g => new
+            {
+                IsAuthenticated = g.Key,
+                PageViews = g.Count(),
+                Sessions = g.Select(pv => pv.SessionId).Distinct().Count()
+            })
+            .ToListAsync(cancellationToken);
+
+        int uniquePages = await query.Select(pv => pv.Path).Distinct().CountAsync(cancellationToken);
+        int uniqueSessions = await query.Select(pv => pv.SessionId).Distinct().CountAsync(cancellationToken);
+
+        int authPageViews = authBreakdowns.FirstOrDefault(x => x.IsAuthenticated)?.PageViews ?? 0;
+        int anonPageViews = authBreakdowns.FirstOrDefault(x => !x.IsAuthenticated)?.PageViews ?? 0;
+        int authSessions = authBreakdowns.FirstOrDefault(x => x.IsAuthenticated)?.Sessions ?? 0;
+        int anonSessions = authBreakdowns.FirstOrDefault(x => !x.IsAuthenticated)?.Sessions ?? 0;
+
         SummaryResponse summary = new(
             WindowStartUtc: windowStartUtc,
             WindowEndUtc: windowEndUtc,
             TotalPageViews: totalCount,
-            UniquePages: await query.Select(pageView => pageView.Path).Distinct().CountAsync(cancellationToken),
-            UniqueSessions: await query.Select(pageView => pageView.SessionId).Distinct().CountAsync(cancellationToken),
-            AuthenticatedPageViews: await query.CountAsync(pageView => pageView.IsAuthenticated, cancellationToken),
-            AnonymousPageViews: await query.CountAsync(pageView => !pageView.IsAuthenticated, cancellationToken),
-            AuthenticatedSessions: await query.Where(pageView => pageView.IsAuthenticated).Select(pageView => pageView.SessionId).Distinct().CountAsync(cancellationToken),
-            AnonymousSessions: await query.Where(pageView => !pageView.IsAuthenticated).Select(pageView => pageView.SessionId).Distinct().CountAsync(cancellationToken));
+            UniquePages: uniquePages,
+            UniqueSessions: uniqueSessions,
+            AuthenticatedPageViews: authPageViews,
+            AnonymousPageViews: anonPageViews,
+            AuthenticatedSessions: authSessions,
+            AnonymousSessions: anonSessions);
 
         List<TopPageResponse> topPages = (await query
             .GroupBy(pageView => pageView.Path)

--- a/src/Quizymode.Api/Features/Collections/GetCollections.cs
+++ b/src/Quizymode.Api/Features/Collections/GetCollections.cs
@@ -51,20 +51,14 @@ public static class GetCollections
         {
             string userId = userContext.UserId!;
 
-            var collections = await db.Collections
+            List<Collection> rawCollections = await db.Collections
+                .AsNoTracking()
                 .Where(c => c.CreatedBy == userId)
                 .OrderByDescending(c => c.CreatedAt)
-                .Select(c => new CollectionResponse(
-                    c.Id.ToString(),
-                    c.Name,
-                    c.Description,
-                    c.CreatedAt,
-                    db.CollectionItems.Count(ci => ci.CollectionId == c.Id),
-                    c.IsPublic))
                 .ToListAsync(cancellationToken);
 
             // Ensure user has at least one collection (Default) on first use (e.g. legacy users; new users get it at signup in UserUpsertMiddleware)
-            if (collections.Count == 0)
+            if (rawCollections.Count == 0)
             {
                 string? displayName = null;
                 if (Guid.TryParse(userId, out Guid parsedUserId))
@@ -83,11 +77,29 @@ public static class GetCollections
                 Collection defaultCollection = DefaultCollectionFactory.Create(userId, displayName);
                 db.Collections.Add(defaultCollection);
                 await db.SaveChangesAsync(cancellationToken);
-                collections = new List<CollectionResponse>
+                return Result.Success(new Response(new List<CollectionResponse>
                 {
                     new(defaultCollection.Id.ToString(), defaultCollection.Name, defaultCollection.Description, defaultCollection.CreatedAt, 0, false)
-                };
+                }));
             }
+
+            // Batch-load item counts with a single GROUP BY instead of a correlated subquery per collection
+            List<Guid> collectionIds = rawCollections.Select(c => c.Id).ToList();
+            Dictionary<Guid, int> itemCounts = await db.CollectionItems
+                .Where(ci => collectionIds.Contains(ci.CollectionId))
+                .GroupBy(ci => ci.CollectionId)
+                .Select(g => new { CollectionId = g.Key, Count = g.Count() })
+                .ToDictionaryAsync(x => x.CollectionId, x => x.Count, cancellationToken);
+
+            List<CollectionResponse> collections = rawCollections
+                .Select(c => new CollectionResponse(
+                    c.Id.ToString(),
+                    c.Name,
+                    c.Description,
+                    c.CreatedAt,
+                    itemCounts.GetValueOrDefault(c.Id),
+                    c.IsPublic))
+                .ToList();
 
             return Result.Success(new Response(collections));
         }

--- a/src/Quizymode.Api/Features/Comments/GetComments.cs
+++ b/src/Quizymode.Api/Features/Comments/GetComments.cs
@@ -57,7 +57,7 @@ public static class GetComments
     {
         try
         {
-            IQueryable<Comment> query = db.Comments.AsQueryable();
+            IQueryable<Comment> query = db.Comments.AsNoTracking();
 
             if (request.ItemId.HasValue && request.ItemId.Value != Guid.Empty)
             {

--- a/src/Quizymode.Api/Features/Ideas/IdeaFeatureSupport.cs
+++ b/src/Quizymode.Api/Features/Ideas/IdeaFeatureSupport.cs
@@ -68,28 +68,31 @@ internal static partial class IdeaFeatureSupport
             .Select(group => new { group.Key, Count = group.Count() })
             .ToDictionaryAsync(row => row.Key, row => row.Count, cancellationToken);
 
-        List<IdeaRating> ratings = await db.IdeaRatings
-            .Where(rating => ideaIds.Contains(rating.IdeaId))
+        // Aggregate rating stats in SQL — avoid loading every rating row into memory
+        var ratingStats = await db.IdeaRatings
+            .Where(rating => ideaIds.Contains(rating.IdeaId) && rating.Stars.HasValue)
+            .GroupBy(rating => rating.IdeaId)
+            .Select(g => new
+            {
+                IdeaId = g.Key,
+                Count = g.Count(),
+                Average = g.Average(r => r.Stars!.Value)
+            })
             .ToListAsync(cancellationToken);
 
-        Dictionary<Guid, int> ratingCounts = ratings
-            .Where(static rating => rating.Stars.HasValue)
-            .GroupBy(static rating => rating.IdeaId)
-            .ToDictionary(group => group.Key, group => group.Count());
-
-        Dictionary<Guid, double?> averageRatings = ratings
-            .Where(static rating => rating.Stars.HasValue)
-            .GroupBy(static rating => rating.IdeaId)
-            .ToDictionary(
-                group => group.Key,
-                group => (double?)Math.Round(group.Average(rating => rating.Stars!.Value), 2));
+        Dictionary<Guid, int> ratingCounts = ratingStats.ToDictionary(x => x.IdeaId, x => x.Count);
+        Dictionary<Guid, double?> averageRatings = ratingStats.ToDictionary(
+            x => x.IdeaId,
+            x => (double?)Math.Round(x.Average, 2));
 
         Dictionary<Guid, int?> myRatings = [];
         if (userContext.IsAuthenticated && !string.IsNullOrWhiteSpace(userContext.UserId))
         {
-            myRatings = ratings
-                .Where(rating => string.Equals(rating.CreatedBy, userContext.UserId, StringComparison.Ordinal))
-                .ToDictionary(rating => rating.IdeaId, rating => rating.Stars);
+            string currentUserId = userContext.UserId;
+            myRatings = await db.IdeaRatings
+                .Where(rating => ideaIds.Contains(rating.IdeaId) && rating.CreatedBy == currentUserId)
+                .Select(rating => new { rating.IdeaId, rating.Stars })
+                .ToDictionaryAsync(x => x.IdeaId, x => x.Stars, cancellationToken);
         }
 
         Dictionary<string, string> displayNames = await ResolveDisplayNamesAsync(

--- a/src/Quizymode.Api/Features/Items/Get/ItemQueryBuilder.cs
+++ b/src/Quizymode.Api/Features/Items/Get/ItemQueryBuilder.cs
@@ -466,12 +466,10 @@ internal sealed class ItemQueryBuilder
             effectiveKeywordIds.Add(chosen.Id);
         }
 
-        // AND semantics: item must have ALL effective keywords
-        foreach (Guid keywordId in effectiveKeywordIds.Distinct())
-        {
-            Guid captured = keywordId;
-            query = query.Where(i => i.ItemKeywords.Any(ik => ik.KeywordId == captured));
-        }
+        // AND semantics: one correlated COUNT is cheaper than N separate EXISTS subqueries
+        List<Guid> distinctKeywordIds = effectiveKeywordIds.Distinct().ToList();
+        int requiredCount = distinctKeywordIds.Count;
+        query = query.Where(i => i.ItemKeywords.Count(ik => distinctKeywordIds.Contains(ik.KeywordId)) == requiredCount);
 
         return Result.Success(query);
     }
@@ -531,12 +529,10 @@ internal sealed class ItemQueryBuilder
             effectiveKeywordIds.Add(chosen.Id);
         }
 
-        // AND semantics: item must have ALL effective keywords
-        foreach (Guid keywordId in effectiveKeywordIds.Distinct())
-        {
-            Guid captured = keywordId;
-            query = query.Where(i => i.ItemKeywords.Any(ik => ik.KeywordId == captured));
-        }
+        // AND semantics: one correlated COUNT is cheaper than N separate EXISTS subqueries
+        List<Guid> distinctKeywordIds = effectiveKeywordIds.Distinct().ToList();
+        int requiredCount = distinctKeywordIds.Count;
+        query = query.Where(i => i.ItemKeywords.Count(ik => distinctKeywordIds.Contains(ik.KeywordId)) == requiredCount);
 
         return Result.Success(query);
     }

--- a/src/Quizymode.Api/Features/Items/Get/ItemQueryExecutor.cs
+++ b/src/Quizymode.Api/Features/Items/Get/ItemQueryExecutor.cs
@@ -50,6 +50,7 @@ internal sealed class ItemQueryExecutor
         GetItems.QueryRequest request)
     {
         List<Item> allItems = await query
+            .AsNoTracking()
             .Include(i => i.ItemKeywords)
                 .ThenInclude(ik => ik.Keyword)
             .Include(i => i.Category)
@@ -67,6 +68,7 @@ internal sealed class ItemQueryExecutor
         GetItems.QueryRequest request)
     {
         return await query
+            .AsNoTracking()
             .Include(i => i.ItemKeywords)
                 .ThenInclude(ik => ik.Keyword)
             .Include(i => i.Category)
@@ -81,6 +83,7 @@ internal sealed class ItemQueryExecutor
         bool isRandom)
     {
         List<Item> allItems = await query
+            .AsNoTracking()
             .Include(i => i.ItemKeywords)
                 .ThenInclude(ik => ik.Keyword)
             .Include(i => i.Category)

--- a/src/Quizymode.Api/Features/Ratings/GetRatings.cs
+++ b/src/Quizymode.Api/Features/Ratings/GetRatings.cs
@@ -54,6 +54,7 @@ public static class GetRatings
         try
         {
             IQueryable<Rating> query = db.Ratings
+                .AsNoTracking()
                 .Where(r => r.ItemId == request.ItemId);
 
             // Only count ratings that have stars (not null)

--- a/src/Quizymode.Api/Migrations/20260411120000_AddPerformanceIndexes.cs
+++ b/src/Quizymode.Api/Migrations/20260411120000_AddPerformanceIndexes.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Quizymode.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerformanceIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // CollectionItems — foreign key columns used in joins and filters had no indexes
+            migrationBuilder.CreateIndex(
+                name: "IX_CollectionItems_CollectionId",
+                table: "CollectionItems",
+                column: "CollectionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CollectionItems_ItemId",
+                table: "CollectionItems",
+                column: "ItemId");
+
+            // Case-insensitive lookup indexes: LOWER(Name) expression indexes allow
+            // queries using k.Name.ToLower() == x to hit the index instead of doing a seq scan.
+            migrationBuilder.Sql(
+                """CREATE INDEX "IX_Keywords_Name_Lower" ON "Keywords" (LOWER("Name"));""");
+
+            migrationBuilder.Sql(
+                """CREATE INDEX "IX_Categories_Name_Lower" ON "Categories" (LOWER("Name"));""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_CollectionItems_CollectionId",
+                table: "CollectionItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CollectionItems_ItemId",
+                table: "CollectionItems");
+
+            migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_Keywords_Name_Lower";""");
+            migrationBuilder.Sql("""DROP INDEX IF EXISTS "IX_Categories_Name_Lower";""");
+        }
+    }
+}

--- a/src/Quizymode.Api/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Quizymode.Api/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -201,6 +201,10 @@ namespace Quizymode.Api.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("CollectionId");
+
+                    b.HasIndex("ItemId");
+
                     b.ToTable("CollectionItems");
                 });
 

--- a/src/Quizymode.Web/package.json
+++ b/src/Quizymode.Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quizymode-web",
   "private": true,
-  "version": "3.18.9",
+  "version": "3.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/Quizymode.Web/package.json
+++ b/src/Quizymode.Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quizymode-web",
   "private": true,
-  "version": "3.18.7",
+  "version": "3.18.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
 What was implemented

  #1 — Migration: AddPerformanceIndexes

  New file 20260411120000_AddPerformanceIndexes.cs + model snapshot update:
  - IX_CollectionItems_CollectionId — fixes all joins between Collections and their items
  - IX_CollectionItems_ItemId — fixes ItemCollectionLoader and item-in-collection lookups
  - IX_Keywords_Name_Lower — expression index on LOWER("Name"), activates when EF translates k.Name.ToLower() to SQL
  - IX_Categories_Name_Lower — same, for category name resolution in ItemQueryBuilder

  #2 — GetCollections.cs — batch item counts

  Replaced the correlated-subquery-per-collection db.CollectionItems.Count(ci => ...) inside .Select() with a single
  GroupBy + ToDictionary call. Added AsNoTracking().

  #3 — IdeaFeatureSupport.cs — SQL aggregation for ratings

  Replaced loading every IdeaRating row into memory and grouping in C# with a single GroupBy SQL query returning {
  IdeaId, Count, Average }. myRatings now fetches only the current user's ratings (a projection, no full entity load).

  #4 — ItemQueryBuilder.cs — expression indexes (migration only)

  The LOWER(Name) expression indexes make the existing k.Name.ToLower() queries index-scannable. No code change needed —
   PostgreSQL uses the index automatically when the query uses lower("Name").

  #5 — ItemQueryBuilder.cs — keyword AND loop

  Both ApplySimpleKeywordFilterAsync and ApplyAndKeywordFilterAsync replaced the foreach-over-EXISTS pattern with a
  single COUNT(...) == requiredCount predicate. With 3 keywords this goes from 3 correlated EXISTS subqueries to 1.

  #6 — AsNoTracking on read-only queries

  Added to GetComments, GetRatings, and all three load paths in ItemQueryExecutor. EF Core no longer allocates a
  change-tracking entry for every loaded entity row.

  #7 — GetPageViewAnalytics.cs — batch summary counts

  Replaced 6 sequential distinct-count queries with a single GroupBy(pv => pv.IsAuthenticated) that returns page-view
  counts and distinct session counts for both visitor types in one round-trip. UniquePages and UniqueSessions remain as
  2 separate queries — total drops from 6 to 3.