### PR TITLE
fix: clean invalid seed keywords

### DIFF
--- a/.agent-skills/quizymode-prepush/SKILL.md
+++ b/.agent-skills/quizymode-prepush/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: quizymode-prepush
+description: Verify Quizymode work before push, including conditional checks, high-risk scans, and a markdown diff-to-main checklist.
+---
+
+# Quizymode Pre-Push
+
+Use this skill when the user asks to prepare Quizymode work for push, run pre-push checks, verify a branch, or produce a ready-to-push summary.
+
+## Scope
+
+Operate from the Quizymode repo root. Treat the effective push scope as the union of:
+
+- committed changes from the current branch compared to `main`
+- staged changes
+- unstaged changes
+- untracked files that appear relevant to the change
+
+## Diff-To-Main Summary
+
+Before running long checks, inspect and summarize the effective diff to `main`.
+
+1. Identify the current branch:
+   - `git branch --show-current`
+2. Resolve the base branch:
+   - prefer `origin/main` if present locally
+   - otherwise use `main`
+3. Inspect committed branch scope:
+   - `git log --oneline <base>..HEAD`
+   - `git diff --stat <base>...HEAD`
+4. Inspect working tree scope:
+   - `git status --short`
+   - `git diff --stat`
+   - `git diff --cached --stat` when staged changes exist
+5. Read key changed files when commit titles and diff stats are not enough.
+6. Produce the change summary as a fenced `md` code block. The `## Summary` section must use only checked checklist items (`- [x]`) for changes that are present in the effective diff:
+
+```md
+## Summary
+- [x] First concrete change
+- [x] Second concrete change
+- [x] Third concrete change
+
+## Verification
+- [x] Command or check that passed
+- [ ] Command not run, with reason
+```
+
+Checklist items should be concrete and outcome-focused. Prefer 3-7 summary items. Mention docs, tests, generated artifacts, and local-only review artifacts when present.
+
+## Verification Workflow
+
+Run the checks that match the effective diff. Do not report ready-to-push work until required checks have passed or you have clearly stated why they could not be run.
+
+### Backend
+
+If any `.cs` file changed, run:
+
+```bash
+dotnet test
+```
+
+### Frontend
+
+If any file under `src/Quizymode.Web/src/` changed, run both:
+
+```bash
+cd src/Quizymode.Web
+npm run build
+npm test -- --run
+```
+
+A passing frontend build alone is not enough. Always run the frontend tests too when frontend source changed.
+
+### OpenAPI
+
+If API surface changed, regenerate and verify the checked-in OpenAPI artifact with:
+
+```powershell
+.\scripts\verify-openapi.ps1 -Configuration Release
+```
+
+Do not hand-edit `docs/openapi/quizymode-api.json` unless explicitly repairing the generation path.
+
+## High-Risk Change Scans
+
+When a record or class constructor signature changed, search all usages across the repo, including tests, and update call sites:
+
+```bash
+rg "LoadedGitHubSeedManifest|OtherTypeName" -g "*.cs"
+```
+
+When a React UI element was removed or renamed, search corresponding tests for stale text, role, label, or attribute assertions:
+
+```bash
+rg "removed-text|removed-link" src/Quizymode.Web/src -g "*.test.*"
+```
+
+When a variable is declared inside an early-return `if` block in a React component, confirm it is not referenced outside that block. If it is referenced by sibling branches or later JSX, hoist it to component scope before the first return.
+
+## Completion Rules
+
+- Update `docs/AC.md` in the same change when behavior, authorization, contract intent, or other user-visible logic changes.
+- Bump `QuizymodeVersion` in `Directory.Build.props` for completed repo changes and keep `src/Quizymode.Web/package.json` aligned.
+- Include a short conventional-commit title suggestion in the final response.
+- Report verification commands with pass/fail status.

--- a/.agent-skills/quizymode-prepush/agents/openai.yaml
+++ b/.agent-skills/quizymode-prepush/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Quizymode Pre-Push"
+  short_description: "Verify Quizymode changes before pushing"
+  default_prompt: "Use $quizymode-prepush to verify this branch before I push it."
+policy:
+  allow_implicit_invocation: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,11 +92,18 @@ dotnet test
 dotnet build src/Quizymode.Api/Quizymode.Api.csproj --configuration Release
 ```
 
+## Pre-Push Verification
+
+Before pushing, run the repo pre-push verification workflow.
+
+If available, invoke the `quizymode-prepush` skill (`$quizymode-prepush`). Otherwise, follow the same workflow from the repo-managed skill at [`.agent-skills/quizymode-prepush/SKILL.md`](./.agent-skills/quizymode-prepush/SKILL.md).
+
 ## Change Rules
 
 - Do not hand-edit generated OpenAPI unless the generation path is broken and you are explicitly repairing it.
 - For repo-managed seed item JSON under `data/seed-source/items`, keep one semantic source file per `category/nav1/nav2` when the set has 100 or fewer items, named `<category>.<nav1>.<nav2>.json`. Split larger sets into 100-item chunks using padded suffixes (`.001`, `.002`, ...), and do not use ad hoc small numbered files such as `.2.json`.
 - When moving, merging, or chunking repo-managed seed items, preserve `itemId` for the same logical item and update generated registries/indexes only through the generation/repair path.
+- **Seed item keyword constraints (enforced by the API):** `navigationKeyword1`, `navigationKeyword2`, and every entry in `keywords[]` must match `^[a-zA-Z0-9\-]+$` and be ≤ 30 characters. Never use full phrases, question text, or multi-word slugs that exceed 30 characters as keywords. Keep keywords short and semantic (e.g. `"piece-of-cake"` not `"make-a-mountain-out-of-a-molehill"`).
 - Do not duplicate large architecture or endpoint inventories across docs.
 - Root `README.md` is the canonical human/AI entry point.
 - Additional README files should be minimal and local in scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,12 @@ cd src/Quizymode.Web && npm test -- --run <pattern>
 
 Before considering any task done, always complete **all** of the following:
 
-1. **Update `docs/AC.md`** — add or revise ACs for any behavior, authorization, or user-visible logic that changed.
-2. **Bump `QuizymodeVersion`** in `Directory.Build.props` — PATCH for fixes/polish, MINOR for new features, MAJOR for breaking changes.
-3. **Align `src/Quizymode.Web/package.json`** `version` field to match `QuizymodeVersion`.
-4. **Suggest a commit title** — include a short conventional-commit title in the final response.
-5. **Regenerate OpenAPI** (`verify-openapi.ps1`) if the API surface changed.
+1. **Run pre-push verification** — invoke the `quizymode-prepush` skill if available, or follow `.agent-skills/quizymode-prepush/SKILL.md` before pushing or reporting ready-to-push work.
+2. **Update `docs/AC.md`** — add or revise ACs for any behavior, authorization, or user-visible logic that changed.
+3. **Bump `QuizymodeVersion`** in `Directory.Build.props` — PATCH for fixes/polish, MINOR for new features, MAJOR for breaking changes.
+4. **Align `src/Quizymode.Web/package.json`** `version` field to match `QuizymodeVersion`.
+5. **Suggest a commit title** — include a short conventional-commit title in the final response.
+6. **Regenerate OpenAPI** (`verify-openapi.ps1`) if the API surface changed.
 
 These rules also live in `AGENTS.md` § Change Rules — this section is a checklist summary to prevent omissions.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <QuizymodeVersion>3.42.1</QuizymodeVersion>
+    <QuizymodeVersion>3.42.3</QuizymodeVersion>
     <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
   </PropertyGroup>
 </Project>

--- a/data/seed-source/items/languages/languages.english.idioms.json
+++ b/data/seed-source/items/languages/languages.english.idioms.json
@@ -1353,7 +1353,6 @@
     "explanation": "'put all your eggs in one basket' is a common English idiom meaning risk everything on a single plan. Literal image: placing every egg in one basket.",
     "keywords": [
       "english",
-      "put-all-your-eggs-in-one-basket",
       "risk"
     ],
     "source": "https://www.merriam-webster.com/dictionary/put%20all%20your%20eggs%20in%20one%20basket"
@@ -1373,7 +1372,6 @@
     "explanation": "'put something on the back burner' is a common English idiom meaning delay something for later. Literal image: moving a pot to the rear burner.",
     "keywords": [
       "english",
-      "put-something-on-the-back-burner",
       "delay"
     ],
     "source": "https://www.merriam-webster.com/dictionary/put%20something%20on%20the%20back%20burner"
@@ -1973,7 +1971,6 @@
     "explanation": "'make a mountain out of a molehill' is a common English idiom meaning exaggerate a small problem. Literal image: turning a tiny hill into a mountain.",
     "keywords": [
       "english",
-      "make-a-mountain-out-of-a-molehill",
       "exaggeration"
     ],
     "source": "https://www.merriam-webster.com/dictionary/make%20a%20mountain%20out%20of%20a%20molehill"

--- a/data/seed-source/items/languages/languages.french.idioms.json
+++ b/data/seed-source/items/languages/languages.french.idioms.json
@@ -408,7 +408,6 @@
     "explanation": "This common French idiom means have more important things to do. Word-to-word: \"to have other cats to whip.\"",
     "keywords": [
       "french",
-      "avoir-d-autres-chats-a-fouetter",
       "priorities"
     ],
     "source": "https://www.wordreference.com/fren/avoir%20d%27autres%20chats%20%C3%A0%20fouetter"
@@ -568,7 +567,6 @@
     "explanation": "This common French idiom means do things in the wrong order. Word-to-word: \"to put the cart before the oxen.\"",
     "keywords": [
       "french",
-      "mettre-la-charrue-avant-les-bufs",
       "order"
     ],
     "source": "https://www.wordreference.com/fren/mettre%20la%20charrue%20avant%20les%20b%C5%93ufs"
@@ -828,7 +826,6 @@
     "explanation": "This common French idiom means go straight into danger. Word-to-word: \"to throw oneself into the wolf's mouth.\"",
     "keywords": [
       "french",
-      "se-jeter-dans-la-gueule-du-loup",
       "danger"
     ],
     "source": "https://www.wordreference.com/fren/se%20jeter%20dans%20la%20gueule%20du%20loup"
@@ -868,7 +865,6 @@
     "explanation": "This common French idiom means have great influence or control. Word-to-word: \"to make the rain and good weather.\"",
     "keywords": [
       "french",
-      "faire-la-pluie-et-le-beau-temps",
       "control"
     ],
     "source": "https://www.wordreference.com/fren/faire%20la%20pluie%20et%20le%20beau%20temps"
@@ -928,7 +924,6 @@
     "explanation": "This common French idiom means face a problem directly. Word-to-word: \"to take the bull by the horns.\"",
     "keywords": [
       "french",
-      "prendre-le-taureau-par-les-cornes",
       "courage"
     ],
     "source": "https://www.wordreference.com/fren/prendre%20le%20taureau%20par%20les%20cornes"
@@ -948,7 +943,6 @@
     "explanation": "This common French idiom means make something more complicated than needed. Word-to-word: \"to look for noon at two o'clock.\"",
     "keywords": [
       "french",
-      "chercher-midi-a-quatorze-heures",
       "overthinking"
     ],
     "source": "https://www.wordreference.com/fren/chercher%20midi%20%C3%A0%20quatorze%20heures"
@@ -1128,7 +1122,6 @@
     "explanation": "This common French idiom means set things straight. Word-to-word: \"to put the clocks back on time.\"",
     "keywords": [
       "french",
-      "remettre-les-pendules-a-l-heure",
       "clarify"
     ],
     "source": "https://www.wordreference.com/fren/remettre%20les%20pendules%20%C3%A0%20l%27heure"
@@ -1498,8 +1491,7 @@
       "french",
       "avoir-la-frite",
       "energy",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-avoir-la-frite"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/avoir%20la%20frite"
   },
@@ -1562,8 +1554,7 @@
       "french",
       "avoir-un-poil-dans-la-main",
       "lazy",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-avoir-un-poil-"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/avoir%20un%20poil%20dans%20la%20main"
   },
@@ -1626,8 +1617,7 @@
       "french",
       "faire-la-grasse-matinee",
       "sleep",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-faire-la-grass"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/faire%20la%20grasse%20matin%C3%A9e"
   },
@@ -1690,8 +1680,7 @@
       "french",
       "prendre-ses-jambes-a-son-cou",
       "escape",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-prendre-ses-ja"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/prendre%20ses%20jambes%20%C3%A0%20son%20cou"
   },
@@ -1752,10 +1741,8 @@
     "explanation": "This common French idiom means have more important things to do. Word-to-word: \"to have other cats to whip.\"",
     "keywords": [
       "french",
-      "avoir-d-autres-chats-a-fouetter",
       "priorities",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-avoir-d-autres"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/avoir%20d%27autres%20chats%20%C3%A0%20fouetter"
   },
@@ -1818,8 +1805,7 @@
       "french",
       "etre-lessive",
       "tired",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-etre-lessive-e"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/%C3%AAtre%20lessiv%C3%A9"
   },
@@ -1883,8 +1869,7 @@
       "french",
       "etre-au-bout-du-rouleau",
       "tired",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-etre-au-bout-d"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/%C3%AAtre%20au%20bout%20du%20rouleau"
   },
@@ -1925,7 +1910,6 @@
     "explanation": "This common French idiom means do things in the wrong order. Word-to-word: \"to put the cart before the oxen.\"",
     "keywords": [
       "french",
-      "mettre-la-charrue-avant-les-bufs",
       "order",
       "idiom-practice"
     ],
@@ -1948,8 +1932,7 @@
       "french",
       "noyer-le-poisson",
       "avoidance",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-noyer-le-poiss"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/noyer%20le%20poisson"
   },
@@ -2012,8 +1995,7 @@
       "french",
       "tourner-autour-du-pot",
       "avoidance",
-      "idiom-practice",
-      "in-everyday-french-what-idea-does-tourner-autour"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/fren/tourner%20autour%20du%20pot"
   },

--- a/data/seed-source/items/languages/languages.italian.idioms.json
+++ b/data/seed-source/items/languages/languages.italian.idioms.json
@@ -689,8 +689,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Solve two problems with one action.'. Word-to-word: \"to take two pigeons with one fava bean.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "prendere-due-piccioni-con-una-fava"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -849,8 +848,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Try to do more than you can handle.'. Word-to-word: \"to take a step longer than the leg.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "fare-il-passo-piu-lungo-della-gamba"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -869,8 +867,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Want incompatible advantages at the same time.'. Word-to-word: \"to have the barrel full and the wife drunk.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "avere-la-botte-piena-e-la-moglie-ubriaca"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -910,8 +907,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Control everything and call the shots.'. Word-to-word: \"to make the good and the bad weather.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "fare-il-bello-e-il-cattivo-tempo"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1014,8 +1010,7 @@
     "keywords": [
       "italian",
       "do-things-in-the-wrong-order",
-      "idiom-practice",
-      "mettere-il-carro-davanti-ai-buoi"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1156,8 +1151,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Not everything turns out perfectly.'. Word-to-word: \"not all doughnuts come out with a hole.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "non-tutte-le-ciambelle-riescono-col-buco"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1300,8 +1294,7 @@
     "explanation": "This item practices the literal image behind the Italian idiom. Word-to-word: \"to take two pigeons with one fava bean.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "prendere-due-piccioni-con-una-fava"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1460,8 +1453,7 @@
     "explanation": "This item practices the literal image behind the Italian idiom. Word-to-word: \"to take a step longer than the leg.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "fare-il-passo-piu-lungo-della-gamba"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1480,8 +1472,7 @@
     "explanation": "This item practices the literal image behind the Italian idiom. Word-to-word: \"to have the barrel full and the wife drunk.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "avere-la-botte-piena-e-la-moglie-ubriaca"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1521,8 +1512,7 @@
     "explanation": "This item practices the literal image behind the Italian idiom. Word-to-word: \"to make the good and the bad weather.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "fare-il-bello-e-il-cattivo-tempo"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1625,8 +1615,7 @@
     "keywords": [
       "italian",
       "do-things-in-the-wrong-order",
-      "idiom-practice",
-      "mettere-il-carro-davanti-ai-buoi"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1767,8 +1756,7 @@
     "explanation": "This item practices the literal image behind the Italian idiom. Word-to-word: \"not all doughnuts come out with a hole.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "non-tutte-le-ciambelle-riescono-col-buco"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },
@@ -1911,8 +1899,7 @@
     "explanation": "This idiom is used in everyday italian for the idea 'Solve two problems with one action.'. Word-to-word: \"to take two pigeons with one fava bean.\"",
     "keywords": [
       "italian",
-      "idiom-practice",
-      "prendere-due-piccioni-con-una-fava"
+      "idiom-practice"
     ],
     "source": "https://dailyitalianwords.com/most-common-italian-idioms/"
   },

--- a/data/seed-source/items/languages/languages.romanian.idioms.json
+++ b/data/seed-source/items/languages/languages.romanian.idioms.json
@@ -878,8 +878,7 @@
     "explanation": "This idiom is used in everyday romanian for the idea 'Use someone else to do the risky work for you.'. Word-to-word: \"to pull the chestnuts from the fire with another person's hand.\"",
     "keywords": [
       "romanian",
-      "idiom-practice",
-      "a-scoate-castanele-din-foc-cu-mana-altuia"
+      "idiom-practice"
     ],
     "source": "https://talkpal.ai/culture/what-are-some-funny-romanian-idioms/"
   },
@@ -1494,8 +1493,7 @@
     "explanation": "This item practices the literal image behind the Romanian idiom. Word-to-word: \"to pull the chestnuts from the fire with another person's hand.\"",
     "keywords": [
       "romanian",
-      "idiom-practice",
-      "a-scoate-castanele-din-foc-cu-mana-altuia"
+      "idiom-practice"
     ],
     "source": "https://talkpal.ai/culture/what-are-some-funny-romanian-idioms/"
   },

--- a/data/seed-source/items/languages/languages.spanish.idioms.json
+++ b/data/seed-source/items/languages/languages.spanish.idioms.json
@@ -408,7 +408,6 @@
     "explanation": "This common Spanish idiom means be trapped between two bad options. Word-to-word: \"to be between the sword and the wall.\"",
     "keywords": [
       "spanish",
-      "estar-entre-la-espada-y-la-pared",
       "dilemma"
     ],
     "source": "https://www.wordreference.com/esen/estar%20entre%20la%20espada%20y%20la%20pared"
@@ -488,7 +487,6 @@
     "explanation": "This common Spanish idiom means be suspicious that something is wrong. Word-to-word: \"to have the fly behind the ear.\"",
     "keywords": [
       "spanish",
-      "tener-la-mosca-detras-de-la-oreja",
       "suspicion"
     ],
     "source": "https://www.wordreference.com/esen/tener%20la%20mosca%20detr%C3%A1s%20de%20la%20oreja"
@@ -808,7 +806,6 @@
     "explanation": "This common Spanish idiom means get along very badly. Word-to-word: \"to get along like dog and cat.\"",
     "keywords": [
       "spanish",
-      "llevarse-como-el-perro-y-el-gato",
       "conflict"
     ],
     "source": "https://www.wordreference.com/esen/llevarse%20como%20el%20perro%20y%20el%20gato"
@@ -928,7 +925,6 @@
     "explanation": "This common Spanish idiom means be full of silly or unrealistic ideas. Word-to-word: \"to have the head full of birds.\"",
     "keywords": [
       "spanish",
-      "tener-la-cabeza-llena-de-pajaros",
       "dreaming"
     ],
     "source": "https://www.wordreference.com/esen/tener%20la%20cabeza%20llena%20de%20p%C3%A1jaros"
@@ -1308,7 +1304,6 @@
     "explanation": "This common Spanish idiom means catch someone in the act. Word-to-word: \"to catch someone with hands in the dough.\"",
     "keywords": [
       "spanish",
-      "pillarlo-con-las-manos-en-la-masa",
       "caught"
     ],
     "source": "https://www.wordreference.com/esen/pillarlo%20con%20las%20manos%20en%20la%20masa"
@@ -1434,8 +1429,7 @@
     "keywords": [
       "spanish",
       "optimism",
-      "idiom-practice",
-      "no-hay-mal-que-por-bien-no-venga"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/no%20hay%20mal%20que%20por%20bien%20no%20venga"
   },
@@ -1498,8 +1492,7 @@
       "spanish",
       "hablar-hasta-por-los-codos",
       "talkative",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-hablar-hasta-"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/hablar%20hasta%20por%20los%20codos"
   },
@@ -1562,8 +1555,7 @@
       "spanish",
       "tirar-la-toalla",
       "quit",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-tirar-la-toal"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/tirar%20la%20toalla"
   },
@@ -1626,8 +1618,7 @@
       "spanish",
       "estar-hecho-polvo",
       "tired",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-estar-hecho-p"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/estar%20hecho%20polvo"
   },
@@ -1690,8 +1681,7 @@
       "spanish",
       "dormir-como-un-tronco",
       "sleep",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-dormir-como-u"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/dormir%20como%20un%20tronco"
   },
@@ -1752,10 +1742,8 @@
     "explanation": "This common Spanish idiom means be trapped between two bad options. Word-to-word: \"to be between the sword and the wall.\"",
     "keywords": [
       "spanish",
-      "estar-entre-la-espada-y-la-pared",
       "dilemma",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-estar-entre-l"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/estar%20entre%20la%20espada%20y%20la%20pared"
   },
@@ -1818,8 +1806,7 @@
       "spanish",
       "ir-al-grano",
       "direct",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-ir-al-grano-e"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/ir%20al%20grano"
   },
@@ -1838,7 +1825,6 @@
     "explanation": "This common Spanish idiom means be suspicious that something is wrong. Word-to-word: \"to have the fly behind the ear.\"",
     "keywords": [
       "spanish",
-      "tener-la-mosca-detras-de-la-oreja",
       "suspicion",
       "idiom-practice"
     ],
@@ -1882,8 +1868,7 @@
       "spanish",
       "estar-sin-blanca",
       "money",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-estar-sin-bla"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/estar%20sin%20blanca"
   },
@@ -1946,8 +1931,7 @@
       "spanish",
       "no-dar-pie-con-bola",
       "mistake",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-no-dar-pie-co"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/no%20dar%20pie%20con%20bola"
   },
@@ -2010,8 +1994,7 @@
       "spanish",
       "estar-como-pez-en-el-agua",
       "comfortable",
-      "idiom-practice",
-      "in-everyday-spanish-what-idea-does-estar-como-pe"
+      "idiom-practice"
     ],
     "source": "https://www.wordreference.com/esen/estar%20como%20pez%20en%20el%20agua"
   },

--- a/src/Quizymode.Api/Features/Admin/SeedSyncAdmin.cs
+++ b/src/Quizymode.Api/Features/Admin/SeedSyncAdmin.cs
@@ -299,13 +299,13 @@ public static class SeedSyncAdmin
                 .NotEmpty()
                 .WithMessage("NavigationKeyword1 is required.")
                 .Must(KeywordHelper.IsValidKeywordNameFormat)
-                .WithMessage("NavigationKeyword1 must use only letters, numbers, and hyphens (max 30 characters).");
+                .WithMessage(x => $"NavigationKeyword1 '{x.NavigationKeyword1}' is invalid: use only letters, numbers, and hyphens (max 30 characters).");
 
             RuleFor(x => x.NavigationKeyword2)
                 .NotEmpty()
                 .WithMessage("NavigationKeyword2 is required.")
                 .Must(KeywordHelper.IsValidKeywordNameFormat)
-                .WithMessage("NavigationKeyword2 must use only letters, numbers, and hyphens (max 30 characters).");
+                .WithMessage(x => $"NavigationKeyword2 '{x.NavigationKeyword2}' is invalid: use only letters, numbers, and hyphens (max 30 characters).");
 
             RuleFor(x => x.Question)
                 .NotEmpty()
@@ -353,7 +353,7 @@ public static class SeedSyncAdmin
                 .NotEmpty()
                 .WithMessage("Keyword names cannot be empty.")
                 .Must(KeywordHelper.IsValidKeywordNameFormat)
-                .WithMessage("Keywords must use only letters, numbers, and hyphens (max 30 characters).");
+                .WithMessage((_, kw) => $"Keyword '{kw}' is invalid: use only letters, numbers, and hyphens (max 30 characters).");
         }
     }
 

--- a/src/Quizymode.Web/package-lock.json
+++ b/src/Quizymode.Web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quizymode-web",
-  "version": "3.41.0",
+  "version": "3.42.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quizymode-web",
-      "version": "3.41.0",
+      "version": "3.42.3",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",

--- a/src/Quizymode.Web/package.json
+++ b/src/Quizymode.Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quizymode-web",
   "private": true,
-  "version": "3.42.1",
+  "version": "3.42.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- [x] Added a repo-managed `quizymode-prepush` skill with a diff-to-main summary, conditional verification workflow, and checked markdown checklist output.
- [x] Updated `AGENTS.md` and `CLAUDE.md` to reference the shared pre-push skill and fallback path.
- [x] Documented API-enforced seed keyword constraints in `AGENTS.md`.
- [x] Removed invalid overlong idiom keywords from English, French, Italian, Romanian, and Spanish seed source files.
- [x] Improved seed sync validation messages to include the invalid navigation keyword or keyword value.
- [x] Bumped app/web version metadata to `3.42.3`, including web lockfile metadata.

## Verification
- [x] `dotnet test --artifacts-path .artifacts\prepush-test` passed: 518 tests.
- [x] Checked idiom seed keywords with a targeted script: all idiom seed keywords are valid.
- [x] Confirmed OpenAPI artifact has no content diff after test-time generation.
- [ ] Frontend build/tests not run because no `src/Quizymode.Web/src/` files changed.
